### PR TITLE
Psp/format uncaught exceptions

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -3,6 +3,7 @@ Base settings to build other settings files upon.
 """
 
 import environ
+from django.core.exceptions import ImproperlyConfigured
 
 ROOT_DIR = (
     environ.Path(__file__) - 3
@@ -217,7 +218,13 @@ if USE_TZ:
     # http://docs.celeryproject.org/en/latest/userguide/configuration.html#std:setting-timezone
     CELERY_TIMEZONE = TIME_ZONE
 # http://docs.celeryproject.org/en/latest/userguide/configuration.html#std:setting-broker_url
-CELERY_BROKER_URL = env("CELERY_BROKER_URL")
+
+try:
+    CELERY_BROKER_URL = env("CELERY_BROKER_URL")
+    print(CELERY_BROKER_URL)
+# This breaks when running tests locally.
+except ImproperlyConfigured:
+    CELERY_BROKER_URL = "redis://0.0.0.0:6379/0"
 # http://docs.celeryproject.org/en/latest/userguide/configuration.html#std:setting-result_backend
 CELERY_RESULT_BACKEND = CELERY_BROKER_URL
 # http://docs.celeryproject.org/en/latest/userguide/configuration.html#std:setting-accept_content

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -221,7 +221,6 @@ if USE_TZ:
 
 try:
     CELERY_BROKER_URL = env("CELERY_BROKER_URL")
-    print(CELERY_BROKER_URL)
 # This breaks when running tests locally.
 except ImproperlyConfigured:
     CELERY_BROKER_URL = "redis://0.0.0.0:6379/0"

--- a/config/urls.py
+++ b/config/urls.py
@@ -52,11 +52,7 @@ if settings.DEBUG:
             default_views.page_not_found,
             kwargs={"exception": Exception("Page not Found")},
         ),
-        url(
-            r"^500/",
-            default_views.server_error,
-            kwargs={"exception": Exception("Error")},
-        ),
+        url(r"^500/", default_views.server_error),
         url(r"^uncaught_exception/", uncaught_exception_view),
     ]
     if "debug_toolbar" in settings.INSTALLED_APPS:

--- a/config/urls.py
+++ b/config/urls.py
@@ -7,6 +7,11 @@ from django.views import defaults as default_views
 
 from django_structlog_demo_project.home import views
 
+
+def uncaught_exception_view(request):
+    raise Exception("Uncaught Exception")
+
+
 urlpatterns = [
     url(r"^$", TemplateView.as_view(template_name="pages/home.html"), name="home"),
     url(
@@ -47,7 +52,12 @@ if settings.DEBUG:
             default_views.page_not_found,
             kwargs={"exception": Exception("Page not Found")},
         ),
-        url(r"^500/", default_views.server_error),
+        url(
+            r"^500/",
+            default_views.server_error,
+            kwargs={"exception": Exception("Error")},
+        ),
+        url(r"^uncaught_exception/", uncaught_exception_view),
     ]
     if "debug_toolbar" in settings.INSTALLED_APPS:
         import debug_toolbar

--- a/django_structlog/celery/receivers.py
+++ b/django_structlog/celery/receivers.py
@@ -43,7 +43,7 @@ def receiver_task_failure(
     task_id=None, exception=None, traceback=None, einfo=None, *args, **kwargs
 ):
 
-    logger.exception("task_failed", error=str(exception))
+    logger.exception("task_failed", error=str(exception), exception=exception)
 
 
 def receiver_task_revoked(

--- a/django_structlog/celery/receivers.py
+++ b/django_structlog/celery/receivers.py
@@ -42,7 +42,8 @@ def receiver_task_success(result=None, **kwargs):
 def receiver_task_failure(
     task_id=None, exception=None, traceback=None, einfo=None, *args, **kwargs
 ):
-    logger.error("task_failed", error=str(exception))
+
+    logger.exception("task_failed", error=str(exception))
 
 
 def receiver_task_revoked(

--- a/django_structlog/middlewares/request.py
+++ b/django_structlog/middlewares/request.py
@@ -51,6 +51,7 @@ class RequestMiddleware(object):
                     error_message=str(e),
                     error_traceback=formatted_traceback,
                     code=HTTP_500_INTERNAL_SERVER_ERROR,
+                    request=request,
                 )
                 raise
             else:

--- a/django_structlog_demo_project/test_app/tests/middlewares/test_request.py
+++ b/django_structlog_demo_project/test_app/tests/middlewares/test_request.py
@@ -153,6 +153,13 @@ class TestRequestMiddleware(TestCase):
         self.assertIn("user_id", record.msg)
         self.assertIsNone(record.msg["user_id"])
 
+        self.assertIn("code", record.msg)
+        self.assertEqual(record.msg["code"], 500)
+        self.assertIn("error_message", record.msg)
+        self.assertEqual(record.msg["error_message"], "This is an exception")
+        self.assertIn("error_traceback", record.msg)
+        self.assertEqual(type(record.msg["error_traceback"]), list)
+        self.assertIn("request", record.msg)
         with self.assertLogs(__name__, logging.INFO) as log_results:
             self.logger.info("hello")
         self.assertEqual(1, len(log_results.records))


### PR DESCRIPTION
I've been using structlog in a django project recently, and we've been using django-structlog to bind a request_id to our log records. It's been super helpful for debugging!

Django logs the stack trace of uncaught exceptions out of the box, and this is generally pretty useful for debugging server errors. 
We've been routing all of our logs through structlog, including django logs, so they get formatted as json, are indexed, and easily searchable.

The only issue with this setup is that request_id is not attached to any of the django logs, as request_id doesn't get bound to the django loggers. So we aren't able to match stack trace information with a specific request 🙁 .

Additionally, it seems that structlog's `ExceptionPrettyPrinter` will swallow keys with the name 'exception':
https://github.com/hynek/structlog/blob/e8b0218cd73eccf1fdb80b49977b801fdac39110/src/structlog/processors.py#L325
So for any application with this processor in the processor chain, it's not being logged fully - just gets printed 🤦‍♂ 


This PR formats the traceback info in the request middleware, and changes the event dict key names being logged. It also adds a code of 500 for consistency, as well as request.

### The main argument for merging this is: Django logs these errors out of the box, so django-structlog should as well.

After these changes:
<img width="1063" alt="Screen Shot 2019-09-03 at 10 13 26 AM" src="https://user-images.githubusercontent.com/26636885/64191378-57f1ae80-ce46-11e9-94ce-ec56df08cf87.png">

I also changed `.error` to `.exception` in the celery failed receiver, so the stack trace should get logged there too.

I've updated the tests to check that everything is working as expected.

I added an `uncaught_excption` route to test this manually, and i made a small modification to the config to get the tests to run locally for me using your instructions.


### Other Solutions

I've explored some other options for accomplishing this, but this route seems like the cleanest. I'm more than happy to hear any suggestions.

@jrobichaud 
@ain2108
@samwblink
@jameslinder7
@chris-daniels
@dvf