### PR TITLE
Remove DRF dependency

### DIFF
--- a/django_structlog/middlewares/request.py
+++ b/django_structlog/middlewares/request.py
@@ -3,7 +3,6 @@ import uuid
 import structlog
 import traceback
 from .. import signals
-from rest_framework.status import HTTP_500_INTERNAL_SERVER_ERROR
 
 logger = structlog.getLogger(__name__)
 
@@ -50,7 +49,7 @@ class RequestMiddleware(object):
                     "request_failed",
                     error_message=str(e),
                     error_traceback=formatted_traceback,
-                    code=HTTP_500_INTERNAL_SERVER_ERROR,
+                    code=500,
                     request=request,
                 )
                 raise


### PR DESCRIPTION
#7 made use of DRF's `HTTP_500_INTERNAL_SERVER_ERROR` without adding it as a dependency.  However that's a fairly large dependency get the literal value `500`.  This removes the dependency and uses the literal int.