### PR TITLE
Add support for user as None

### DIFF
--- a/django_structlog/middlewares/request.py
+++ b/django_structlog/middlewares/request.py
@@ -20,13 +20,19 @@ class RequestMiddleware(object):
     def __init__(self, get_response):
         self.get_response = get_response
 
+    def check_user_into_request(self, request):
+        return True if getattr(request, 'user', None) else False
+
     def __call__(self, request):
         from ipware import get_client_ip
 
         request_id = str(uuid.uuid4())
         with structlog.threadlocal.tmp_bind(logger):
             logger.bind(request_id=request_id)
-            logger.bind(user_id=request.user.id)
+
+            if self.check_user_into_request(request):
+                logger.bind(user_id=request.user.id)
+
             ip, routable = get_client_ip(request)
             logger.bind(ip=ip)
             signals.bind_extra_request_metadata.send(

--- a/django_structlog_demo_project/test_app/tests/middlewares/test_request.py
+++ b/django_structlog_demo_project/test_app/tests/middlewares/test_request.py
@@ -16,6 +16,36 @@ class TestRequestMiddleware(TestCase):
         self.factory = RequestFactory()
         self.logger = structlog.getLogger(__name__)
 
+    def test_user_removed_from_request(self):
+        mock_response = Mock()
+        mock_response.status_code.return_value = 200
+        expected_uuid = "00000000-0000-0000-0000-000000000000"
+        self.log_results = None
+
+        def get_response(_response):
+            with self.assertLogs(__name__, logging.INFO) as log_results:
+                self.logger.info("hello")
+            self.log_results = log_results
+            return mock_response
+
+        request = self.factory.get("/foo")
+
+        middleware = middlewares.RequestMiddleware(get_response)
+        with patch("uuid.UUID.__str__", return_value=expected_uuid):
+            middleware(request)
+
+        self.assertEqual(1, len(self.log_results.records))
+        record = self.log_results.records[0]
+
+        self.assertEqual("INFO", record.levelname)
+        self.assertIn("request_id", record.msg)
+        self.assertEqual(expected_uuid, record.msg["request_id"])
+        with self.assertLogs(__name__, logging.INFO) as log_results:
+            self.logger.info("hello")
+        self.assertEqual(1, len(log_results.records))
+        record = log_results.records[0]
+        self.assertNotIn("request_id", record.msg)
+
     def test_process_request_anonymous(self):
         mock_response = Mock()
         mock_response.status_code.return_value = 200


### PR DESCRIPTION
When you remove `user` middleware from django, in my case trying to convert django in microservice framework, the user attribute was deleted from request object and send Exception because is mandatory into `RequestMiddleware`.

I just create a validation for bind user id