### PR TITLE
Bind X-Correlation-ID HTTP header's value as correlation_id when prov…

### DIFF
--- a/docs/events.rst
+++ b/docs/events.rst
@@ -25,7 +25,9 @@ These metadata are repeated on each log of the current request and will be also 
 +------------------+------------------------------------------------------------------------------------------+
 | Key              | Value                                                                                    |
 +==================+==========================================================================================+
-| request_id       | UUID for the request or value of ``HTTP_X_REQUEST_ID`` header when provided              |
+| request_id       | UUID for the request or value of ``X-Request-ID`` HTTP header when provided              |
++------------------+------------------------------------------------------------------------------------------+
+| correlation_id   | value of ``X-Correlation-ID`` HTTP header when provided                                  |
 +------------------+------------------------------------------------------------------------------------------+
 | user_id          | user's id or None (requires `django.contrib.auth.middleware.AuthenticationMiddleware`_)  |
 +------------------+------------------------------------------------------------------------------------------+


### PR DESCRIPTION
…ided

This complement X-Request-ID support that was added in #22 