### PR TITLE
Older celery

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -93,8 +93,6 @@ LOGIN_URL = "account_login"
 # ------------------------------------------------------------------------------
 # https://docs.djangoproject.com/en/dev/ref/settings/#password-hashers
 PASSWORD_HASHERS = [
-    # https://docs.djangoproject.com/en/dev/topics/auth/passwords/#using-argon2-with-django
-    "django.contrib.auth.hashers.Argon2PasswordHasher",
     "django.contrib.auth.hashers.PBKDF2PasswordHasher",
     "django.contrib.auth.hashers.PBKDF2SHA1PasswordHasher",
     "django.contrib.auth.hashers.BCryptSHA256PasswordHasher",

--- a/docs/celery.rst
+++ b/docs/celery.rst
@@ -1,6 +1,8 @@
 Celery Integration
 ==================
 
+``django-structlog`` supports ``celery`` 4.1 or higher. This is likely to change to follow `celery 4.5's release cycle <https://github.com/celery/celery/issues/4957>`_
+
 Getting Started with Celery
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -1,6 +1,5 @@
 pytz==2018.9  # https://github.com/stub42/pytz
 python-slugify==3.0.2  # https://github.com/un33k/python-slugify
-argon2-cffi==19.1.0  # https://github.com/hynek/argon2_cffi
 whitenoise==4.1.2  # https://github.com/evansd/whitenoise
 redis==3.2.1  # https://github.com/antirez/redis
 celery==4.3.0  # pyup: < 5.0  # https://github.com/celery/celery

--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,8 @@ envlist =
     py{35,36,37}-django111-celery43,
     py{35,36,37}-django2{0,1,2}-celery43,
     py{36,37,38}-django3{0}-celery44,
+    py36-django22-celery4{1,2},
+    py35-django22-celery4{0},
 
 [testenv]
 setenv =
@@ -14,6 +16,9 @@ setenv =
     CELERY_BROKER_URL=redis://0.0.0.0:6379
     DJANGO_SETTINGS_MODULE=config.settings.test
 deps =
+    celery40: Celery >=4.0, <4.1
+    celery41: Celery >=4.1, <4.2
+    celery42: Celery >=4.2, <4.3
     celery43: Celery >=4.3, <4.4
     celery44: Celery >=4.4, <4.5
     django111: Django >=1.11, <2.0

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,6 @@ envlist =
     py{35,36,37}-django2{0,1,2}-celery43,
     py{36,37,38}-django3{0}-celery44,
     py36-django22-celery4{1,2},
-    py35-django22-celery4{0},
 
 [testenv]
 setenv =
@@ -16,7 +15,6 @@ setenv =
     CELERY_BROKER_URL=redis://0.0.0.0:6379
     DJANGO_SETTINGS_MODULE=config.settings.test
 deps =
-    celery40: Celery >=4.0, <4.1
     celery41: Celery >=4.1, <4.2
     celery42: Celery >=4.2, <4.3
     celery43: Celery >=4.3, <4.4


### PR DESCRIPTION
|Celery  |Demo works| Test runs |Notes | 
|--------|----------|-----------|-----------------------------------------| 
| 4.2.2  | ✅       | ✅       |                                         |
| 4.1.1  | ✅       | ✅       | Python36                                |
| 4.0.2  | ❌       | ✅        | Python35 kombu==4.1.0 billiard==3.5.0.2 (no black) |
|        |          |           | django-structlog_celeryworker_1 exited with code 1 |
| 3.1.26 | ❌       | ❌       | Some breaking changes in celery         |
