### PR TITLE
Celery 3 compatibility

### DIFF
--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -1,4 +1,4 @@
-redis==3.3.11  # https://github.com/antirez/redis
+redis<3  # https://github.com/antirez/redis
 flower==0.9.3  # https://github.com/mher/flower
 
 # Django

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -1,7 +1,7 @@
 pytz==2018.9  # https://github.com/stub42/pytz
 python-slugify==3.0.2  # https://github.com/un33k/python-slugify
 whitenoise==4.1.2  # https://github.com/evansd/whitenoise
-redis==3.2.1  # https://github.com/antirez/redis
+redis<3  # https://github.com/antirez/redis
 celery<4  # pyup: < 5.0  # https://github.com/celery/celery
 flower==0.9.3  # https://github.com/mher/flower
 kombu<4


### PR DESCRIPTION
I just downgraded python redis to < 3,
It might be worth to keep two sets of requirements one for celery 3 and one for celery 4 because same versions of kombu and redis might not work across different combinations of celery and python