### PR TITLE
Remove results

### DIFF
--- a/django_structlog/celery/receivers.py
+++ b/django_structlog/celery/receivers.py
@@ -48,7 +48,7 @@ def receiver_task_retry(request=None, reason=None, einfo=None, **kwargs):
 
 
 def receiver_task_success(result=None, **kwargs):
-    logger.info("task_succeed", result=str(result))
+    logger.info("task_succeeded")
 
 
 def receiver_task_failure(


### PR DESCRIPTION
Hi ! thanks for your work, this is a very nice project.

I created this PR to remove the results from the celery task success signal, I did not find a way to conveniently make this configurable, if you have any ideas please let me know.

