### PR TITLE
Address deprecation warning emitted by django 3.1

### DIFF
--- a/django_structlog/celery/signals.py
+++ b/django_structlog/celery/signals.py
@@ -1,7 +1,7 @@
 import django.dispatch
 
 
-bind_extra_task_metadata = django.dispatch.Signal(providing_args=["task", "logger"])
+bind_extra_task_metadata = django.dispatch.Signal()
 """ Signal to add extra ``structlog`` bindings from ``celery``'s task.
 
 >>> from django.dispatch import receiver
@@ -14,7 +14,7 @@ bind_extra_task_metadata = django.dispatch.Signal(providing_args=["task", "logge
 """
 
 
-modify_context_before_task_publish = django.dispatch.Signal(providing_args=["context"])
+modify_context_before_task_publish = django.dispatch.Signal()
 """ Signal to modify context passed over to ``celery`` task's context. You must modify the ``context`` dict.
 
 >>> from django.dispatch import receiver
@@ -33,7 +33,7 @@ modify_context_before_task_publish = django.dispatch.Signal(providing_args=["con
 
 """
 
-pre_task_succeeded = django.dispatch.Signal(providing_args=["task", "logger", "result"])
+pre_task_succeeded = django.dispatch.Signal()
 """ Signal to add ``structlog`` bindings from ``celery``'s successful task.
 
 >>> from django.dispatch import receiver

--- a/django_structlog/signals.py
+++ b/django_structlog/signals.py
@@ -1,9 +1,7 @@
 import django.dispatch
 
 
-bind_extra_request_metadata = django.dispatch.Signal(
-    providing_args=["request", "logger"]
-)
+bind_extra_request_metadata = django.dispatch.Signal()
 """ Signal to add extra ``structlog`` bindings from ``django``'s request.
 
 >>> from django.dispatch import receiver
@@ -15,9 +13,7 @@ bind_extra_request_metadata = django.dispatch.Signal(
 
 """
 
-bind_extra_request_finished_metadata = django.dispatch.Signal(
-    providing_args=["request", "logger", "response"]
-)
+bind_extra_request_finished_metadata = django.dispatch.Signal()
 """ Signal to add extra ``structlog`` bindings from ``django``'s finished request and response.
 
 >>> from django.dispatch import receiver
@@ -29,9 +25,7 @@ bind_extra_request_finished_metadata = django.dispatch.Signal(
 
 """
 
-bind_extra_request_failed_metadata = django.dispatch.Signal(
-    providing_args=["request", "logger", "exception"]
-)
+bind_extra_request_failed_metadata = django.dispatch.Signal()
 """ Signal to add extra ``structlog`` bindings from ``django``'s failed request and exception.
 
 >>> from django.dispatch import receiver


### PR DESCRIPTION
```
RemovedInDjango40Warning: The providing_args argument is deprecated.
As it is purely documentational, it has no replacement.
If you rely on this argument as documentation,
you can move the text to a code comment or docstring.
```