### PR TITLE
Remove pypy from pypi tags

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,6 @@ setup(
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
-        "Programming Language :: Python :: Implementation :: PyPy",
         "Topic :: System :: Logging",
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",


### PR DESCRIPTION
This tag was never supposed to be there in the first place.