### PR TITLE
Improve formatting of exceptions

### DIFF
--- a/django_structlog/middlewares/request.py
+++ b/django_structlog/middlewares/request.py
@@ -84,7 +84,7 @@ class RequestMiddleware:
         self._raised_exception = True
 
         traceback_object = exception.__traceback__
-        formatted_traceback = traceback.format_tb(traceback_object)
+        formatted_traceback = ''.join(traceback.format_tb(traceback_object))
         self.bind_user_id(request),
         signals.bind_extra_request_failed_metadata.send(
             sender=self.__class__, request=request, logger=logger, exception=exception


### PR DESCRIPTION
traceback.format_tb() returns a list of str that each end with "\n".
This makes it really hard to read the traceback.

Concat the list into a single string for improved readability.