### PR TITLE
Handle PermissionDenied like Http404

### DIFF
--- a/django_structlog/middlewares/request.py
+++ b/django_structlog/middlewares/request.py
@@ -1,6 +1,7 @@
 import uuid
 
 import structlog
+from django.core.permissions import PermissionDenied
 from django.http import Http404
 
 from .. import signals
@@ -74,7 +75,7 @@ class RequestMiddleware:
         return response
 
     def process_exception(self, request, exception):
-        if isinstance(exception, Http404):
+        if isinstance(exception, (Http404, PermissionDenied)):
             # We don't log an exception here, and we don't set that we handled
             # an error as we want the standard `request_finished` log message
             # to be emitted.

--- a/django_structlog/middlewares/request.py
+++ b/django_structlog/middlewares/request.py
@@ -1,7 +1,7 @@
 import uuid
 
 import structlog
-from django.core.permissions import PermissionDenied
+from django.core.exceptions import PermissionDenied
 from django.http import Http404
 
 from .. import signals

--- a/test_app/tests/middlewares/test_request.py
+++ b/test_app/tests/middlewares/test_request.py
@@ -5,6 +5,7 @@ from unittest import mock
 from unittest.mock import patch, Mock
 
 from django.contrib.auth.models import AnonymousUser, User
+from django.core.exceptions import PermissionDenied
 from django.dispatch import receiver
 from django.http import Http404, HttpResponseNotFound
 from django.test import TestCase, RequestFactory
@@ -453,6 +454,55 @@ class TestRequestMiddleware(TestCase):
         self.assertNotIn("request_id", record.msg)
         self.assertNotIn("user_id", record.msg)
 
+    def test_process_request_403_are_processed_as_regular_requests(self):
+        expected_uuid = "00000000-0000-0000-0000-000000000000"
+
+        request = self.factory.get("/foo")
+        request.user = AnonymousUser()
+
+        middleware = middlewares.RequestMiddleware(None)
+
+        exception = PermissionDenied()
+
+        def get_response(_response):
+            """ Simulate an exception """
+            middleware.process_exception(request, exception)
+            return HttpResponseNotFound()
+
+        middleware.get_response = get_response
+
+        with patch("uuid.UUID.__str__", return_value=expected_uuid), self.assertLogs(
+            logging.getLogger("django_structlog"), logging.INFO
+        ) as log_results:
+            middleware(request)
+
+        self.assertEqual(2, len(log_results.records))
+        record = log_results.records[0]
+        self.assertEqual("INFO", record.levelname)
+        self.assertIn("request_id", record.msg)
+        self.assertEqual(expected_uuid, record.msg["request_id"])
+        self.assertIn("user_id", record.msg)
+        self.assertIsNone(record.msg["user_id"])
+
+        record = log_results.records[1]
+        self.assertEqual("INFO", record.levelname)
+        self.assertIn("request_id", record.msg)
+        self.assertEqual(expected_uuid, record.msg["request_id"])
+        self.assertIn("user_id", record.msg)
+        self.assertIsNone(record.msg["user_id"])
+
+        self.assertIn("code", record.msg)
+        self.assertEqual(record.msg["code"], 404)
+        self.assertNotIn("exception", record.msg)
+        self.assertIn("request", record.msg)
+
+        with self.assertLogs(__name__, logging.INFO) as log_results:
+            self.logger.info("hello")
+        self.assertEqual(1, len(log_results.records))
+        record = log_results.records[0]
+        self.assertNotIn("request_id", record.msg)
+        self.assertNotIn("user_id", record.msg)
+    
     def test_process_request_404_are_processed_as_regular_requests(self):
         expected_uuid = "00000000-0000-0000-0000-000000000000"
 

--- a/test_app/tests/middlewares/test_request.py
+++ b/test_app/tests/middlewares/test_request.py
@@ -7,7 +7,7 @@ from unittest.mock import patch, Mock
 from django.contrib.auth.models import AnonymousUser, User
 from django.core.exceptions import PermissionDenied
 from django.dispatch import receiver
-from django.http import Http404, HttpResponseNotFound
+from django.http import Http404, HttpResponseNotFound, HttpResponseForbidden
 from django.test import TestCase, RequestFactory
 import structlog
 
@@ -467,7 +467,7 @@ class TestRequestMiddleware(TestCase):
         def get_response(_response):
             """ Simulate an exception """
             middleware.process_exception(request, exception)
-            return HttpResponseNotFound()
+            return HttpResponseForbidden()
 
         middleware.get_response = get_response
 
@@ -492,7 +492,7 @@ class TestRequestMiddleware(TestCase):
         self.assertIsNone(record.msg["user_id"])
 
         self.assertIn("code", record.msg)
-        self.assertEqual(record.msg["code"], 404)
+        self.assertEqual(record.msg["code"], 403)
         self.assertNotIn("exception", record.msg)
         self.assertIn("request", record.msg)
 


### PR DESCRIPTION
Django's PermissionDenied is used very similar to the Http404, I think that should be handled the same way.
here's the doc:
https://docs.djangoproject.com/en/3.2/ref/urls/#handler403
https://docs.djangoproject.com/en/3.2/ref/views/#django.views.defaults.permission_denied