### PR TITLE
Include merge_contextvers in foreign_pre_chain to inject contextvers into standard library logs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -338,10 +338,12 @@ Changes you need to do
 
 - add ``structlog.contextvars.merge_contextvars`` as first processors (line 3)
 - remove ``context_class=structlog.threadlocal.wrap_dict(dict),`` (line 14)
+- add ``structlog.contextvars.merge_contextvars`` for foreign_pre_chain (line 29)
+- remove ``django_structlog.processors.inject_context_dict,`` (line 30)
 
 
 .. code-block:: python
-   :emphasize-lines:  3,14
+   :emphasize-lines:  3,14,29,30
    :linenos:
 
    structlog.configure(
@@ -362,6 +364,27 @@ Changes you need to do
        wrapper_class=structlog.stdlib.BoundLogger,
        cache_logger_on_first_use=True,
    )
+
+   LOGGING = {
+       "version": 1,
+       "disable_existing_loggers": False,
+       "formatters": {
+           "json_formatter": {
+               "()": structlog.stdlib.ProcessorFormatter,
+               "processor": structlog.processors.JSONRenderer(),
+               # ADD THIS SECTION
+               "foreign_pre_chain": [
+                   structlog.contextvars.merge_contextvars,
+                   # django_structlog.processors.inject_context_dict,
+                   structlog.processors.TimeStamper(fmt="iso"),
+                   structlog.stdlib.add_logger_name,
+                   structlog.stdlib.add_log_level,
+                   structlog.stdlib.PositionalArgumentsFormatter(),
+               ],
+           },
+       },
+       ...
+    }
 
 2. Replace all ``logger.bind`` with ``structlog.contextvars.bind_contextvars``
 ------------------------------------------------------------------------------

--- a/config/settings/local.py
+++ b/config/settings/local.py
@@ -87,6 +87,7 @@ LOGGING = {
             "()": structlog.stdlib.ProcessorFormatter,
             "processor": structlog.processors.JSONRenderer(),
             "foreign_pre_chain": [
+                structlog.contextvars.merge_contextvars,
                 structlog.processors.TimeStamper(fmt="iso"),
                 structlog.stdlib.add_logger_name,
                 structlog.stdlib.add_log_level,
@@ -97,6 +98,7 @@ LOGGING = {
             "()": structlog.stdlib.ProcessorFormatter,
             "processor": structlog.dev.ConsoleRenderer(colors=True),
             "foreign_pre_chain": [
+                structlog.contextvars.merge_contextvars,
                 structlog.processors.TimeStamper(fmt="iso"),
                 structlog.stdlib.add_logger_name,
                 structlog.stdlib.add_log_level,
@@ -109,6 +111,7 @@ LOGGING = {
                 key_order=["timestamp", "level", "event", "logger"]
             ),
             "foreign_pre_chain": [
+                structlog.contextvars.merge_contextvars,
                 structlog.processors.TimeStamper(fmt="iso"),
                 structlog.stdlib.add_logger_name,
                 structlog.stdlib.add_log_level,


### PR DESCRIPTION
to fix https://github.com/jrobichaud/django-structlog/pull/78#issuecomment-1200491072

## problem

@jrobichaud wrote
> there is a regression when using standard logger no one took the time to look at. I might consider release the new version with the regression and document it.

The cause of the problem is that after removing the `django_structlog.processors.inject_context_dict` that was in `foreign_pre_chain` [code](https://github.com/jrobichaud/django-structlog/pull/78/files#diff-d699d1610cb06e78bfedaca679279700e61d4f448aa6e7cfe83f5d044a0968d3L91), it did not have `merge_contextverses`. This meant that information that was previously merged via `context_class=structlog.threadlocal.wrap_dict(dict)` was no longer being injected.

> <img width="1016" alt="image" src="https://user-images.githubusercontent.com/151623/182140377-d44bcb52-79d8-453d-9eff-4c3685f1c139.png">
```
django-structlog-django-1        | 2022-08-01T10:39:16.097959Z [info     ] request_started                [django_structlog.middlewares.request] ip=172.19.0.1 request=POST /standard_logger request_id=262fe17c-c7c1-4c34-9ff6-f402671615fc user_agent=Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/103.0.5060.134 Safari/537.36 user_id=None
django-structlog-django-1        | 2022-08-01T10:39:16.102237Z [info     ] This is a standard logger      [foreign_logger] 
django-structlog-django-1        | 2022-08-01T10:39:16.103166Z [info     ] request_finished               [django_structlog.middlewares.request] code=200 ip=172.19.0.1 request=POST /standard_logger request_id=262fe17c-c7c1-4c34-9ff6-f402671615fc user_id=None
django-structlog-django-1        | 172.19.0.1 - - [01/Aug/2022 10:39:16] "POST /standard_logger HTTP/1.1" 200 -
```

## by this PR

By including `merge_contextvers` in `foreign_pre_chain`, we were able to inject the contextvers information into the standard library log.

> <img width="1024" alt="image" src="https://user-images.githubusercontent.com/151623/182140325-6e9da347-984c-44f2-8237-d83647e890cd.png">
```
django-structlog-django-1        | 2022-08-01T11:02:47.049768Z [info     ] request_started                [django_structlog.middlewares.request] ip=172.19.0.1 request=POST /standard_logger request_id=df0661ee-a705-42bb-a26d-c1732717b0a4 user_agent=Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/103.0.5060.134 Safari/537.36 user_id=None
django-structlog-django-1        | 2022-08-01T11:02:47.054468Z [info     ] This is a standard logger      [foreign_logger] ip=172.19.0.1 request_id=df0661ee-a705-42bb-a26d-c1732717b0a4 user_id=None
django-structlog-django-1        | 2022-08-01T11:02:47.058848Z [info     ] request_finished               [django_structlog.middlewares.request] code=200 ip=172.19.0.1 request=POST /standard_logger request_id=df0661ee-a705-42bb-a26d-c1732717b0a4 user_id=None
django-structlog-django-1        | 172.19.0.1 - - [01/Aug/2022 11:02:47] "POST /standard_logger HTTP/1.1" 200 -
```