### PR TITLE
Fix issue when generating doc

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -5,3 +5,4 @@ django>=3.2,<5
 structlog
 sphinx-autobuild==2021.3.14
 Jinja2<3.1
+importlib-metadata>=1,<5

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,5 @@
-sphinx<2
-sphinx_rtd_theme
+sphinx<5
+sphinx_rtd_theme<2
 celery==5.2.7
 django>=3.2,<5
 structlog


### PR DESCRIPTION

```
django-structlog-docs-docs-1       | looking for now-outdated files... WARNING: autodoc: failed to import module 'steps' from module 'django_structlog.celery'; the following exception was raised:
django-structlog-docs-docs-1       | Traceback (most recent call last):
django-structlog-docs-docs-1       |   File "/usr/local/lib/python3.7/site-packages/sphinx/ext/autodoc/importer.py", line 154, in import_module
django-structlog-docs-docs-1       |     __import__(modname)
django-structlog-docs-docs-1       |   File "/app/django_structlog/celery/steps.py", line 1, in <module>
django-structlog-docs-docs-1       |     from celery import bootsteps
django-structlog-docs-docs-1       |   File "/usr/local/lib/python3.7/site-packages/celery/bootsteps.py", line 6, in <module>
django-structlog-docs-docs-1       |     from kombu.common import ignore_errors
django-structlog-docs-docs-1       |   File "/usr/local/lib/python3.7/site-packages/kombu/common.py", line 14, in <module>
django-structlog-docs-docs-1       |     from .entity import Exchange, Queue
django-structlog-docs-docs-1       |   File "/usr/local/lib/python3.7/site-packages/kombu/entity.py", line 7, in <module>
django-structlog-docs-docs-1       |     from .serialization import prepare_accept_content
django-structlog-docs-docs-1       |   File "/usr/local/lib/python3.7/site-packages/kombu/serialization.py", line 440, in <module>
django-structlog-docs-docs-1       |     for ep, args in entrypoints('kombu.serializers'):  # pragma: no cover
django-structlog-docs-docs-1       |   File "/usr/local/lib/python3.7/site-packages/kombu/utils/compat.py", line 82, in entrypoints
django-structlog-docs-docs-1       |     for ep in importlib_metadata.entry_points().get(namespace, [])
django-structlog-docs-docs-1       | AttributeError: 'EntryPoints' object has no attribute 'get'
```