### PR TITLE
Fix: Do not block event loop when using middleware asynchronously

### DIFF
--- a/django_structlog/middlewares/request.py
+++ b/django_structlog/middlewares/request.py
@@ -128,6 +128,7 @@ class AsyncRequestMiddleware(BaseRequestMiddleWare):
         # (coroutine has been deprecated in Python 3.11)
         return await self.get_response(request)
 
+
 class RequestMiddleware(SyncRequestMiddleware):
     """``RequestMiddleware`` adds request metadata to ``structlog``'s logger context automatically.
 

--- a/django_structlog/middlewares/request.py
+++ b/django_structlog/middlewares/request.py
@@ -148,5 +148,6 @@ def request_middleware_router(get_response):
 
     """
     if asyncio.iscoroutinefunction(get_response):
-        return AsyncRequestMiddleware(get_response)
+        # coroutine can be started and resumed so it doesn't block the event loop
+        return AsyncRequestMiddleware(asyncio.coroutine(get_response))
     return SyncRequestMiddleware(get_response)


### PR DESCRIPTION
Hi, how are you?

I am using your library in the project and I appreciate your work. I'm currently working on async and enabling parallelization of custom processes in django by putting a django asgi container on gunicorn.
As the documentation indicates:
> You will only get the benefits of a fully-asynchronous request stack if you have no synchronous middleware loaded into your site. If there is a piece of synchronous middleware, then Django must use a thread per request to safely emulate a synchronous environment for it.

And according to the changes you made a while ago here:
https://github.com/jrobichaud/django-structlog/pull/188/files#diff-4ddec93ed217fe3bb1b0720f34f6bb9c4df1f5d864026a069eb0843a3cbc3bfaR139
this middleware can be used both synchronously and asynchronously, which is also mentioned in the documentation here:
https://docs.djangoproject.com/en/4.1/topics/http/middleware/#asynchronous-support

In the project I'm working on, I also have other middlewares implemented this way. However, I ran into a stumbling block when I wanted to run a certain process entirely asynchronously (using API, database I/O, and so on). It turns out that the functions with the @sync_and_async_middleware decorator correctly select the async middleware variant, while for some reason the event loop is blocked by it and the tasks start to execute one after another instead of concurrently.

Assuming a very simple middleware call method and a very simple function:

```python
     async def __call__(self, request):
         response = await self.get_response(request)
         return response
```

```python
     async task_blocking_event_loop():
         print('Time to sleep!')
         await asyncio.sleep(30)
         return True
```

Turning on any middleware in the django container means that, for example, calling this function 5 times will take a total of 150 seconds and prints will appear every 30 seconds. It was tested by me that commenting out all the middlewares cleared the event loop and made all 5 prints appear.

So I started looking for a solution, and the simplest and most effective turned out to be the introduction of coroutine (literally) to middleware. For some reason ``get_response``, which is a key element consumed in the middleware, blocks the event loop, and the ability to start and stop it with coroutine suddenly clears the entire event loop. Uncommented all middleware and it works! 5 tasks completed in just over 30 seconds on a single django instance.

I can of course import your SyncRequestMiddleware, AsyncRequestMiddleware to project and create custom version of request_middleware_router, but I think it's worth having such things in the main library, because maybe there will be others with the same problem. In my pull request, I proposed the least invasive idea to add coroutine there, but of course feel free to put them elsewhere, e.g. I was also thinking of overwriting init in AsyncRequestMiddleware. Maybe it will turn out that you have some other idea and a working solution?

Have a good one