### PR TITLE
Add update_failure_response signal

### DIFF
--- a/django_structlog/signals.py
+++ b/django_structlog/signals.py
@@ -47,3 +47,22 @@ bind_extra_request_failed_metadata = django.dispatch.Signal()
 ...     structlog.contextvars.bind_contextvars(user_email=getattr(request.user, 'email', ''))
 
 """
+
+update_failure_response = django.dispatch.Signal()
+""" Signal to update response failure response before it is returned.
+
+:param request: the request returned by the view
+:param response: the response resulting of the request
+:param logger: the logger
+:param exception: the exception
+
+>>> from django.dispatch import receiver
+>>> from django_structlog import signals
+>>> import structlog
+>>>
+>>> @receiver(signals.update_failure_response)
+... def add_request_id_to_error_response(request, response, logger, exception, **kwargs):
+...     context = structlog.contextvars.get_merged_contextvars(logger)
+...     response['X-Request-ID'] = context["request_id"]
+
+"""

--- a/docs/api_documentation.rst
+++ b/docs/api_documentation.rst
@@ -15,7 +15,7 @@ django_structlog
     :show-inheritance:
 
 .. automodule:: django_structlog.signals
-    :members: bind_extra_request_metadata, bind_extra_request_finished_metadata, bind_extra_request_failed_metadata
+    :members: bind_extra_request_metadata, bind_extra_request_finished_metadata, bind_extra_request_failed_metadata, update_failure_response
 
 
 django_structlog.celery

--- a/test_app/tests/middlewares/test_request.py
+++ b/test_app/tests/middlewares/test_request.py
@@ -387,7 +387,7 @@ class TestRequestMiddleware(TestCase):
 
         @receiver(bind_extra_request_failed_metadata)
         def receiver_bind_extra_request_metadata(
-            sender, signal, request=None, logger=None, exception=None
+            sender, signal, request=None, response=None, logger=None, exception=None
         ):
             self.assertEqual(exception, expected_exception)
             structlog.contextvars.bind_contextvars(


### PR DESCRIPTION
Example usage:
```python
from django.dispatch import receiver
from django_structlog import signals
import structlog


@receiver(signals.update_failure_response)
@receiver(signals.bind_extra_request_finished_metadata)
def add_request_id_to_error_response(response, logger, **kwargs):
    context = structlog.contextvars.get_merged_contextvars(logger)
    response['X-Request-ID'] = context["request_id"]
```

closes #231 