### PR TITLE
Replace celery middleware initialization with a setting

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -339,14 +339,14 @@ Json file (\ ``logs/json.log``\ )
 Upgrade Guide
 =============
 
-.. _upgrade_5.0:
+.. _upgrade_6.0:
 
-Upgrading to 5.0+
-^^^^^^^^^^^^^^^^^
+Upgrading to 6.0+ (upcoming)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Minimum requirements
 ~~~~~~~~~~~~~~~~~~~~
-- requires asgiref 3.6+
+- requires python 3.8+
 
 Change you may need to do
 ~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -364,11 +364,33 @@ Make sure you use ``django_structlog.middlewares.RequestMiddleware`` instead of 
         # "django_structlog.middlewares.requests.SyncRequestMiddleware", # <- remove
         # "django_structlog.middlewares.requests.AsyncRequestMiddleware", # <- remove
         "django_structlog.middlewares.RequestMiddleware", # <- make sure you use this one
-        "django_structlog.middlewares.CeleryMiddleware",
     ]
 
-They will be removed in another major version.
 
+Make sure you use ``DJANGO_STRUCTLOG_CELERY_ENABLED = True``
+------------------------------------------------------------
+
+It is only applicable if you use celery integration.
+
+``django_structlog.middlewares.CeleryMiddleware`` has been remove in favor of a django settings.
+
+.. code-block:: python
+
+    MIDDLEWARE += [
+        "django_structlog.middlewares.RequestMiddleware",
+        # "django_structlog.middlewares.CeleryMiddleware",  # <- remove this
+    ]
+
+    DJANGO_STRUCTLOG_CELERY_ENABLED = True # <-- add this
+
+.. _upgrade_5.0:
+
+Upgrading to 5.0+
+^^^^^^^^^^^^^^^^^
+
+Minimum requirements
+~~~~~~~~~~~~~~~~~~~~
+- requires asgiref 3.6+
 
 .. _upgrade_4.0:
 

--- a/config/settings/local.py
+++ b/config/settings/local.py
@@ -161,5 +161,6 @@ structlog.configure(
 
 MIDDLEWARE += [
     "django_structlog.middlewares.RequestMiddleware",
-    "django_structlog.middlewares.CeleryMiddleware",
 ]
+
+DJANGO_STRUCTLOG_USE_CELERY = True

--- a/django_structlog/__init__.py
+++ b/django_structlog/__init__.py
@@ -4,6 +4,6 @@
 
 name = "django_structlog"
 
-VERSION = (5, 2, 0)
+VERSION = (5, 3, 0)
 
 __version__ = ".".join(str(v) for v in VERSION)

--- a/django_structlog/app_settings.py
+++ b/django_structlog/app_settings.py
@@ -2,7 +2,7 @@ from django.conf import settings
 
 
 # noinspection PyPep8Naming
-class Settings:
+class AppSettings:
     PREFIX = "DJANGO_STRUCTLOG_"
 
     @property
@@ -10,4 +10,4 @@ class Settings:
         return getattr(settings, self.PREFIX + "CELERY_ENABLED", False)
 
 
-app_settings = Settings()
+app_settings = AppSettings()

--- a/django_structlog/app_settings.py
+++ b/django_structlog/app_settings.py
@@ -1,0 +1,13 @@
+from django.conf import settings
+
+
+# noinspection PyPep8Naming
+class Settings:
+    PREFIX = "DJANGO_STRUCTLOG_"
+
+    @property
+    def CELERY_ENABLED(self):
+        return getattr(settings, self.PREFIX + "CELERY_ENABLED", False)
+
+
+app_settings = Settings()

--- a/django_structlog/apps.py
+++ b/django_structlog/apps.py
@@ -1,5 +1,13 @@
 from django.apps import AppConfig
 
+from .app_settings import app_settings
+
 
 class DjangoStructLogConfig(AppConfig):
     name = "django_structlog"
+
+    def ready(self):
+        if app_settings.CELERY_ENABLED:
+            from .celery.receivers import connect_celery_signals
+
+            connect_celery_signals()

--- a/django_structlog/celery/middlewares.py
+++ b/django_structlog/celery/middlewares.py
@@ -1,8 +1,15 @@
 from asgiref.sync import iscoroutinefunction, markcoroutinefunction
+from django.utils.deprecation import warn_about_renamed_method
 
-from ..celery.receivers import receiver_before_task_publish, receiver_after_task_publish
+from .receivers import connect_celery_signals
 
 
+@warn_about_renamed_method(
+    class_name="django_structlog.middlewares",
+    old_method_name="CeleryMiddleware",
+    new_method_name="DJANGO_STRUCTLOG_CELERY_ENABLED = True",
+    deprecation_warning=DeprecationWarning,
+)
 class CeleryMiddleware:
     sync_capable = True
     async_capable = True
@@ -19,10 +26,8 @@ class CeleryMiddleware:
 
     def __init__(self, get_response=None):
         self.get_response = get_response
-        from celery.signals import before_task_publish, after_task_publish
 
-        before_task_publish.connect(receiver_before_task_publish)
-        after_task_publish.connect(receiver_after_task_publish)
+        connect_celery_signals()
         if iscoroutinefunction(self.get_response):
             markcoroutinefunction(self)
 

--- a/django_structlog/celery/receivers.py
+++ b/django_structlog/celery/receivers.py
@@ -90,3 +90,10 @@ def receiver_task_unknown(message=None, exc=None, name=None, id=None, **kwargs):
 
 def receiver_task_rejected(message=None, exc=None, **kwargs):
     logger.error("task_rejected", message=message)
+
+
+def connect_celery_signals():
+    from celery.signals import before_task_publish, after_task_publish
+
+    before_task_publish.connect(receiver_before_task_publish)
+    after_task_publish.connect(receiver_after_task_publish)

--- a/django_structlog/middlewares/request.py
+++ b/django_structlog/middlewares/request.py
@@ -144,7 +144,7 @@ class RequestMiddleware(BaseRequestMiddleWare):
 
 
 @warn_about_renamed_method(
-    class_name="django-structlog.middlewares",
+    class_name="django_structlog.middlewares",
     old_method_name="SyncRequestMiddleware",
     new_method_name="RequestMiddleware",
     deprecation_warning=DeprecationWarning,
@@ -154,7 +154,7 @@ class SyncRequestMiddleware(RequestMiddleware):
 
 
 @warn_about_renamed_method(
-    class_name="django-structlog.middlewares",
+    class_name="django_structlog.middlewares",
     old_method_name="AsyncRequestMiddleware",
     new_method_name="RequestMiddleware",
     deprecation_warning=DeprecationWarning,
@@ -164,7 +164,7 @@ class AsyncRequestMiddleware(RequestMiddleware):
 
 
 @warn_about_renamed_method(
-    class_name="django-structlog.middlewares",
+    class_name="django_structlog.middlewares",
     old_method_name="request_middleware_router",
     new_method_name="RequestMiddleware",
     deprecation_warning=DeprecationWarning,

--- a/docs/api_documentation.rst
+++ b/docs/api_documentation.rst
@@ -26,11 +26,6 @@ django_structlog.celery
     :undoc-members:
     :show-inheritance:
 
-.. automodule:: django_structlog.celery.middlewares
-    :members: CeleryMiddleware
-    :undoc-members:
-    :show-inheritance:
-
 .. automodule:: django_structlog.celery.steps
     :members: DjangoStructLogInitStep
     :undoc-members:

--- a/docs/celery.rst
+++ b/docs/celery.rst
@@ -18,8 +18,8 @@ Replace ``django-structlog`` with ``django-structlog[celery]`` in your ``require
 
     django-structlog[celery]==X.Y.Z
 
-Add CeleryMiddleWare in your web app
-------------------------------------
+Enable celery integration in your web app
+-----------------------------------------
 
 In your settings.py
 
@@ -28,8 +28,9 @@ In your settings.py
     MIDDLEWARE = [
         # ...
         'django_structlog.middlewares.RequestMiddleware',
-        'django_structlog.middlewares.CeleryMiddleware',
     ]
+
+    DJANGO_STRUCTLOG_CELERY_ENABLED = True
 
 
 Initialize Celery Worker with DjangoStructLogInitStep

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,31 @@
 Change Log
 ==========
 
+6.0 (tbd)
+---------
+
+See: :ref:`upgrade_6.0`
+
+*Changes:*
+    - Drop support of python 3.7
+    - Drop legacy code still supporting celery < 4
+    - Removal of deprecated:
+        - :class:`django_structlog.middlewares.CeleryMiddleware`
+        - :class:`django_structlog.middlewares.SyncRequestMiddleware`
+        - :class:`django_structlog.middlewares.AsyncRequestMiddleware`
+        - :class:`django_structlog.middlewares.request_middleware_router`
+
+
+5.3.0 (June 30, 2023)
+---------------------
+
+*New:*
+    - django setting ``DJANGO_STRUCTLOG_CELERY_ENABLED = True`` replacing :class:`django_structlog.middlewares.CeleryMiddleware`. See :ref:`upgrade_6.0` and `#265 <https://github.com/jrobichaud/django-structlog/pull/265>`_. Also introduce new internal `app_settings` that may come handy for future configurations.
+
+
+*Deprecations:*
+    - :class:`django_structlog.middlewares.CeleryMiddleware` (see above).
+
 
 5.2.0 (June 29, 2023)
 ---------------------

--- a/docs/events.rst
+++ b/docs/events.rst
@@ -65,8 +65,8 @@ These metadata appear once along with their associated event
 
 .. _format_exc_info: https://www.structlog.org/en/stable/api.html#structlog.processors.format_exc_info
 
-CeleryMiddleware
-----------------
+Celery
+------
 
 Task Events
 ^^^^^^^^^^^

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,7 +84,6 @@ build-backend = "setuptools.build_meta"
         py37-django32-celery51-redis{3,4}-kombu5-importlibmetadata4,
         py{38,39,310}-django32-celery51-redis{3,4}-kombu5,
         py{38,39,310,311}-django4{0,1,2}-celery5{2,3}-redis{3,4}-kombu5,
-    pip_pre = True
 
     [gh-actions]
     python =

--- a/test_app/tests/celery/test_receivers.py
+++ b/test_app/tests/celery/test_receivers.py
@@ -1,6 +1,6 @@
 import logging
 from unittest import mock
-from unittest.mock import Mock
+from unittest.mock import Mock, patch, call
 
 import structlog
 from celery import shared_task
@@ -392,3 +392,24 @@ class TestReceivers(TestCase):
         self.assertEqual("ERROR", record.levelname)
         self.assertIn("message", record.msg)
         self.assertEqual(expected_message, record.msg["message"])
+
+
+class TestConnectCelerySignals(TestCase):
+    def test_call(self):
+        from celery.signals import before_task_publish, after_task_publish
+        from django_structlog.celery.receivers import (
+            receiver_before_task_publish,
+            receiver_after_task_publish,
+        )
+
+        with patch(
+            "celery.utils.dispatch.signal.Signal.connect", autospec=True
+        ) as mock_connect:
+            receivers.connect_celery_signals()
+
+        mock_connect.assert_has_calls(
+            [
+                call(before_task_publish, receiver_before_task_publish),
+                call(after_task_publish, receiver_after_task_publish),
+            ]
+        )

--- a/test_app/tests/test_app_settings.py
+++ b/test_app/tests/test_app_settings.py
@@ -5,13 +5,13 @@ from django_structlog import app_settings
 
 class TestAppSettings(TestCase):
     def test_celery_enabled(self):
-        settings = app_settings.Settings()
+        settings = app_settings.AppSettings()
 
         with self.settings(DJANGO_STRUCTLOG_CELERY_ENABLED=True):
             self.assertTrue(settings.CELERY_ENABLED)
 
     def test_celery_disabled(self):
-        settings = app_settings.Settings()
+        settings = app_settings.AppSettings()
 
         with self.settings(DJANGO_STRUCTLOG_CELERY_ENABLED=False):
             self.assertFalse(settings.CELERY_ENABLED)

--- a/test_app/tests/test_app_settings.py
+++ b/test_app/tests/test_app_settings.py
@@ -1,0 +1,17 @@
+from django.test import TestCase
+
+from django_structlog import app_settings
+
+
+class TestAppSettings(TestCase):
+    def test_celery_enabled(self):
+        settings = app_settings.Settings()
+
+        with self.settings(DJANGO_STRUCTLOG_CELERY_ENABLED=True):
+            self.assertTrue(settings.CELERY_ENABLED)
+
+    def test_celery_disabled(self):
+        settings = app_settings.Settings()
+
+        with self.settings(DJANGO_STRUCTLOG_CELERY_ENABLED=False):
+            self.assertFalse(settings.CELERY_ENABLED)

--- a/test_app/tests/test_apps.py
+++ b/test_app/tests/test_apps.py
@@ -1,0 +1,29 @@
+from unittest.mock import patch
+
+from django.test import TestCase
+
+from django_structlog import apps
+
+
+class TestAppConfig(TestCase):
+    def test_celery_enabled(self):
+        app = apps.DjangoStructLogConfig(
+            "django_structlog", __import__("django_structlog")
+        )
+        with patch(
+            "django_structlog.celery.receivers.connect_celery_signals"
+        ) as mock_connect_celery_signals:
+            with self.settings(DJANGO_STRUCTLOG_CELERY_ENABLED=True):
+                app.ready()
+        mock_connect_celery_signals.assert_called_once()
+
+    def test_celery_disabled(self):
+        app = apps.DjangoStructLogConfig(
+            "django_structlog", __import__("django_structlog")
+        )
+        with patch(
+            "django_structlog.celery.receivers.connect_celery_signals"
+        ) as mock_connect_celery_signals:
+            with self.settings(DJANGO_STRUCTLOG_CELERY_ENABLED=False):
+                app.ready()
+        mock_connect_celery_signals.assert_not_called()


### PR DESCRIPTION
CeleryMiddleware has nothing to do with django's request mechanism.

Using a django middleware for this adds useless (maybe negligible) overhead with each request.

This PR replace the CeleryMiddleware with a new setting.

```python
DJANGO_STRUCTLOG_CELERY_ENABLED = True
```