### PR TITLE
Huey integration

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -60,6 +60,7 @@ THIRD_PARTY_APPS = [
     "allauth.account",
     "allauth.socialaccount",
     "rest_framework",
+    "huey.contrib.djhuey",
 ]
 LOCAL_APPS = [
     "django_structlog_demo_project.command_examples",

--- a/config/settings/local.py
+++ b/config/settings/local.py
@@ -1,5 +1,8 @@
 import structlog
 
+from django_structlog.huey import RedisHuey
+from redis import ConnectionPool
+
 from .base import *  # noqa: F403
 from .base import env, MIDDLEWARE
 
@@ -129,6 +132,14 @@ LOGGING = {
         },
     },
     "loggers": {
+        "huey": {
+            "handlers": ["colored_stream", "flat_line_file", "json_file"],
+            "level": "INFO",
+        },
+        "huey.consumer": {
+            "handlers": ["colored_stream", "flat_line_file", "json_file"],
+            "level": "INFO",
+        },
         "django_structlog": {
             "handlers": ["colored_stream", "flat_line_file", "json_file"],
             "level": "INFO",
@@ -167,3 +178,7 @@ MIDDLEWARE += [
 
 DJANGO_STRUCTLOG_CELERY_ENABLED = True
 DJANGO_STRUCTLOG_COMMAND_LOGGING_ENABLED = True
+DJANGO_STRUCTLOG_HUEY_ENABLED = True
+
+pool = ConnectionPool(host="redis", port=6379, max_connections=20)
+HUEY = RedisHuey("my-app", connection_pool=pool)

--- a/config/urls.py
+++ b/config/urls.py
@@ -30,6 +30,7 @@ urlpatterns = [
     ),
     re_path(r"^async_view", views.async_view, name="async_view"),
     re_path(r"^api_view$", api_views.home_api_view, name="api_view"),
+    re_path(r"^huey_task$", views.enqueue_huey_task, name="enqueue_huey_task"),
     re_path(
         r"^about/", TemplateView.as_view(template_name="pages/about.html"), name="about"
     ),

--- a/django_structlog/app_settings.py
+++ b/django_structlog/app_settings.py
@@ -12,6 +12,10 @@ class AppSettings:
         return getattr(settings, self.PREFIX + "CELERY_ENABLED", False)
 
     @property
+    def HUEY_ENABLED(self):
+        return getattr(settings, self.PREFIX + "HUEY_ENABLED", False)
+
+    @property
     def STATUS_4XX_LOG_LEVEL(self):
         return getattr(settings, self.PREFIX + "STATUS_4XX_LOG_LEVEL", logging.WARNING)
 

--- a/django_structlog/apps.py
+++ b/django_structlog/apps.py
@@ -16,3 +16,8 @@ class DjangoStructLogConfig(AppConfig):
             from .commands import init_command_signals
 
             init_command_signals()
+
+        if app_settings.HUEY_ENABLED:
+            from .huey.receivers import connect_huey_signals
+
+            connect_huey_signals()

--- a/django_structlog/huey/__init__.py
+++ b/django_structlog/huey/__init__.py
@@ -1,0 +1,14 @@
+from huey import Huey as OriginalHuey
+from huey.storage import RedisStorage
+
+
+class Huey(OriginalHuey):
+    def enqueue(self, task):
+        # TODO: See https://github.com/coleifer/huey/pull/771
+        if not self._immediate:
+            self._emit("enqueue", task)
+        return super().enqueue(task)
+
+
+class RedisHuey(Huey):
+    storage_class = RedisStorage

--- a/django_structlog/huey/receivers.py
+++ b/django_structlog/huey/receivers.py
@@ -1,0 +1,46 @@
+from django.conf import settings
+import structlog
+
+from django_structlog.celery import signals
+
+logger = structlog.getLogger(__name__)
+
+STORAGE_KEY = "__django_structlog__"
+
+
+def all_signal_handler(signal, task, exc=None):
+    from huey import signals as S
+
+    if signal == "enqueue":
+        context = structlog.contextvars.get_merged_contextvars(logger)
+
+        signals.modify_context_before_task_publish.send(
+            sender=all_signal_handler, context=context
+        )
+        if "task_id" in context:
+            context["parent_task_id"] = context.pop("task_id")
+
+        # TODO: See https://github.com/coleifer/huey/issues/772
+        task.kwargs[STORAGE_KEY] = context  # <- storage hack
+
+        logger.info(
+            "task_enqueued",
+            child_task_id=task.id,
+            child_task_name=task.name,
+        )
+    if signal == S.SIGNAL_EXECUTING:
+        if STORAGE_KEY in task.kwargs:
+            context = task.kwargs[STORAGE_KEY]  # <- storage hack
+            del task.kwargs[STORAGE_KEY]  # <- storage hack
+
+            structlog.contextvars.bind_contextvars(task_id=task.id)
+            structlog.contextvars.bind_contextvars(**context)
+            signals.bind_extra_task_metadata.send(
+                sender=all_signal_handler, task=task, logger=logger
+            )
+            logger.info("task_started", task=task.name)
+
+
+def connect_huey_signals():
+    signal = settings.HUEY.signal
+    signal()(all_signal_handler)

--- a/django_structlog_demo_project/home/views.py
+++ b/django_structlog_demo_project/home/views.py
@@ -10,6 +10,10 @@ from django_structlog_demo_project.taskapp.celery import (
     rejected_task,
 )
 
+from django_structlog_demo_project.taskapp.huey import (
+    huey_task,
+)
+
 logger = structlog.get_logger(__name__)
 
 
@@ -66,3 +70,9 @@ async def async_view(request):
 
 def raise_exception(request):
     raise Exception("This is a view raising an exception.")
+
+
+def enqueue_huey_task(request):
+    task = huey_task()
+    logger.info("enqueue_huey_task", task_id=task.id)
+    return HttpResponse(status=201)

--- a/django_structlog_demo_project/taskapp/huey.py
+++ b/django_structlog_demo_project/taskapp/huey.py
@@ -1,0 +1,16 @@
+from django.conf import settings
+
+import structlog
+from huey import crontab
+
+logger = structlog.getLogger(__name__)
+
+
+@settings.HUEY.task()
+def huey_task():
+    logger.info("huey task")
+
+
+@settings.HUEY.periodic_task(crontab(minute="*/1"))
+def huey_scheduled_task():
+    logger.info("huey scheduled task")

--- a/django_structlog_demo_project/templates/pages/home.html
+++ b/django_structlog_demo_project/templates/pages/home.html
@@ -68,6 +68,13 @@
         <button type="submit" form="form_revoke_task">Celery: Revoke task</button>
     </div>
 
+    <div>
+        <form action="{% url 'enqueue_huey_task' %}" method="post" id="form_enqueue_huey_task" target="dummyframe">
+            {% csrf_token %}
+        </form>
+        <button type="submit" form="form_enqueue_huey_task">Huey: Enqueue task</button>
+    </div>
+
     <span><iframe width="0" height="0" border="0" name="dummyframe" id="dummyframe" style="visibility: hidden;"></iframe></span>
 
 {% endblock %}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -60,6 +60,19 @@ services:
     command: /start-celeryworker
     tty: true # needed for colors to show in console logs
 
+  hueyworker:
+    image: django_structlog_demo_project_local_django
+    depends_on:
+      - redis
+      - postgres
+    volumes:
+      - .:/app:cached
+    env_file:
+      - ./.envs/.local/.django
+      - ./.envs/.local/.postgres
+
+    command: ./manage.py run_huey
+    tty: true # needed for colors to show in console logs
   celerybeat:
     image: django_structlog_demo_project_local_django
     depends_on:

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -5,3 +5,4 @@ celery==5.3.4  # pyup: < 5.0  # https://github.com/celery/celery
 kombu==5.3.2
 flower==2.0.1  # https://github.com/mher/flower
 uvicorn==0.23.2 # https://github.com/encode/uvicorn
+huey==2.5.0 # https://github.com/coleifer/huey


### PR DESCRIPTION
These hacks work but it requires changes in huey in order to integrate seamlessly.

In order to achieve this two things are needed:

1.  A signal before the task is being enqueued. Implemented by https://github.com/coleifer/huey/pull/771.
2. Being able to store metadata from the context of the task being enqueued then recover the data in the consumer before the task is executed. Ex: have a task.context dict field where I can store metadata.  https://github.com/coleifer/huey/issues/772

Apparently the changes required will not be part of huey so unless people really want it even if the implementation is hacked, I will cancel the project to integrate huey.