### PR TITLE
Explicit task protocol instead of celery's version

### DIFF
--- a/django_structlog_demo_project/taskapp/celery.py
+++ b/django_structlog_demo_project/taskapp/celery.py
@@ -96,14 +96,11 @@ def rejected_task():
     pass
 
 
-if not settings.IS_WORKER:
+if not settings.IS_WORKER:  # pragma: no branch
 
     @shared_task
     def unknown_task():
         """Simulate a task unavailable in the worker for demonstration purpose"""
-
-else:  # pragma: no cover
-    pass
 
 
 @signals.before_task_publish.connect

--- a/docs/celery.rst
+++ b/docs/celery.rst
@@ -57,6 +57,15 @@ In your celery AppConfig's module.
     app.steps['worker'].add(DjangoStructLogInitStep)
 
 
+.. warning::
+    If you use ``celery``'s `task_protocol v1 <https://docs.celeryq.dev/en/stable/userguide/configuration.html#task-protocol>`_, ``django-structlog`` will not be able to transfer metadata to child task.
+
+    Ex:
+
+    .. code-block:: python
+
+        app = Celery("your_celery_project", task_protocol=1)
+
 Configure celery's logger
 -------------------------
 


### PR DESCRIPTION
Task protocol v2 was introduced in celery 3 but defaulted to protocol v2 in celery 4.

Historically storing data in the body of the task with protocol v1 and celery 3.X worked.

However, I realized lately it was not celery's version that was deciding if it was using body or header but the `task_protocol`.

I am pretty sure most people use the default value of `task_protocol` which is v2.