### PR TITLE
Changes to use python-ipware

### DIFF
--- a/django_structlog/middlewares/request.py
+++ b/django_structlog/middlewares/request.py
@@ -19,6 +19,25 @@ def get_request_header(request, header_key, meta_key):
 
     return request.META.get(meta_key)
 
+def get_client_ip(request):
+    from ipware import IpWare
+
+    # Instantiate IpWare with default values
+    ipw = IpWare()
+
+    # Get the request headers for Django 4.0
+    if hasattr(request, "headers"):
+        meta = request.headers
+
+    # Get the request headers for Django < 4
+    else:
+        meta = request.META
+
+    # Get the client IP
+    ip, _ = ipw.get_client_ip(meta)
+
+    # Cast IP to string
+    return str(ip), _
 
 class BaseRequestMiddleWare:
     def __init__(self, get_response):
@@ -57,9 +76,8 @@ class BaseRequestMiddleWare:
             )
         structlog.contextvars.clear_contextvars()
 
-    def prepare(self, request):
-        from ipware import get_client_ip
 
+    def prepare(self, request):
         request_id = get_request_header(
             request, "x-request-id", "HTTP_X_REQUEST_ID"
         ) or str(uuid.uuid4())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ build-backend = "setuptools.build_meta"
     "django>=3.2",
     "structlog>=21.4.0",
     "asgiref>=3.6.0",
-    "django-ipware",
+    "python-ipware",
   ]
   classifiers = [
     "Development Status :: 5 - Production/Stable",

--- a/requirements/local-base.txt
+++ b/requirements/local-base.txt
@@ -17,7 +17,7 @@ coreapi==2.3.3  # https://github.com/core-api/python-client
 
 structlog==23.2.0
 colorama==0.4.6
-django-ipware==5.0.1
+python-ipware==1.0.5  # https://github.com/un33k/python-ipware
 
 Werkzeug==3.0.0  # https://github.com/pallets/werkzeug
 ipdb==0.13.13  # https://github.com/gotcha/ipdb


### PR DESCRIPTION
As django-ipware is being deprecated in favor of python-ipware, and the fact they share the same import namespace any project python-ipware

**This is on hold until a conclusion is reached for https://github.com/un33k/python-ipware/issues/10**