### PR TITLE
+ python 3.13, - python 3.8

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - '3.12'
+          - '3.13'
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
@@ -42,11 +42,11 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - '3.8'
           - '3.9'
           - '3.10'
           - '3.11'
           - '3.12'
+          - '3.13'
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
@@ -75,7 +75,7 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - '3.12'
+          - '3.13'
     steps:
       - uses: actions/checkout@v4
       - name: Install dependencies
@@ -97,7 +97,7 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - '3.12'
+          - '3.13'
     steps:
       - uses: actions/checkout@v4
       - name: Install dependencies
@@ -115,7 +115,7 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - '3.12'
+          - '3.13'
     steps:
       - uses: actions/checkout@v4
       - name: Install dependencies
@@ -131,7 +131,7 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - '3.12'
+          - '3.13'
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
@@ -157,7 +157,7 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - '3.12'
+          - '3.13'
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
@@ -188,7 +188,7 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - '3.12'
+          - '3.13'
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -15,7 +15,7 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: 3.12
+          python-version: 3.13
 
       - uses: browniebroke/pre-commit-autoupdate-action@v1.0.0
 

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -7,9 +7,9 @@ version: 2
 
 # Set the version of Python and other tools you might need
 build:
-  os: ubuntu-22.04
+  os: ubuntu-24.04
   tools:
-    python: "3.12"
+    python: "3.13"
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:

--- a/compose/local/django/entrypoint
+++ b/compose/local/django/entrypoint
@@ -20,17 +20,17 @@ postgres_ready() {
 python << END
 import sys
 
-import psycopg2
+import psycopg
 
 try:
-    psycopg2.connect(
+    psycopg.connect(
         dbname="${POSTGRES_DB}",
         user="${POSTGRES_USER}",
         password="${POSTGRES_PASSWORD}",
         host="${POSTGRES_HOST}",
         port="${POSTGRES_PORT}",
     )
-except psycopg2.OperationalError:
+except psycopg.OperationalError:
     sys.exit(-1)
 sys.exit(0)
 

--- a/django_structlog/__init__.py
+++ b/django_structlog/__init__.py
@@ -3,6 +3,6 @@
 
 name = "django_structlog"
 
-VERSION = (8, 1, 0)
+VERSION = (9, 0, 0)
 
 __version__ = ".".join(str(v) for v in VERSION)

--- a/docker-compose.docs.yml
+++ b/docker-compose.docs.yml
@@ -4,7 +4,7 @@ services:
       context: .
       dockerfile: ./compose/local/docs/Dockerfile
       args:
-        PYTHON_VERSION: 3.12
+        PYTHON_VERSION: 3.13
     image: django_structlog_demo_project_docs
     volumes:
       - .:/app:cached

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       context: .
       dockerfile: ./compose/local/django/Dockerfile
       args:
-        PYTHON_VERSION: 3.12
+        PYTHON_VERSION: 3.13
     image: django_structlog_demo_project_local_django
     depends_on:
       - postgres

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,10 +1,12 @@
 Change Log
 ==========
 
-TBD
----
+9.0.0 (TBD)
+-----------
 
 *Changes:*
+    - Add python 3.13 support. See `#674 <https://github.com/jrobichaud/django-structlog/pull/674>`_.
+    - Drop python 3.8 support. See `#674 <https://github.com/jrobichaud/django-structlog/pull/674>`_.
     - Django 5.1 and celery 5.4 support. See `#617 <https://github.com/jrobichaud/django-structlog/pull/617>`_.
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ build-backend = "setuptools.build_meta"
   ]
   readme = "README.rst"
   dynamic = ["version"]
-  requires-python = ">=3.8"
+  requires-python = ">=3.9"
   license = { text = "MIT" }
   dependencies = [
     "django>=4.2",
@@ -26,11 +26,11 @@ build-backend = "setuptools.build_meta"
     "Framework :: Django :: 5.1",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Topic :: System :: Logging",
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
@@ -63,11 +63,11 @@ build-backend = "setuptools.build_meta"
 [tool.black]
   line-length = 88
   target-version = [
-    'py38',
     'py39',
     'py310',
     'py311',
     'py312',
+    'py313',
   ]
   include = '\.pyi?$'
   exclude = '''
@@ -85,7 +85,7 @@ build-backend = "setuptools.build_meta"
 
 [tool.ruff]
   line-length = 88
-  target-version = "py312"
+  target-version = "py313"
   lint.ignore = [
     'E501',
   ]
@@ -100,17 +100,18 @@ build-backend = "setuptools.build_meta"
     #
     # Also, make sure that all python versions used here are included in ./github/worksflows/main.yml
     envlist =
-        py{38,39,310,311}-django42-celery5{2,3}-redis{3,4}-kombu5,
+        py{39,310,311}-django42-celery5{2,3}-redis{3,4}-kombu5,
         py31{0,1}-django5{0,1}-celery5{3,4}-redis4-kombu5,
         py312-django{42,50,51}-celery5{3,4}-redis4-kombu5,
+        py313-django{51}-celery5{3,4}-redis4-kombu5,
 
     [gh-actions]
     python =
-        3.8: py38
         3.9: py39
         3.10: py310
         3.11: py311
         3.12: py312
+        3.13: py313
 
     [testenv]
     setenv =

--- a/requirements/local-base.txt
+++ b/requirements/local-base.txt
@@ -25,7 +25,7 @@ django-ipware==7.0.1
 
 Werkzeug==3.0.4  # https://github.com/pallets/werkzeug
 ipdb==0.13.13  # https://github.com/gotcha/ipdb
-psycopg2-binary==2.9.9 # https://github.com/psycopg/psycopg2
+psycopg[binary]==3.2.3 # https://github.com/psycopg/psycopg
 
 # Testing
 # ------------------------------------------------------------------------------

--- a/test_app/tests/middlewares/test_request.py
+++ b/test_app/tests/middlewares/test_request.py
@@ -244,9 +244,12 @@ class TestRequestMiddleware(TestCase):
             return mock_response
 
         middleware = middlewares.RequestMiddleware(get_response)
-        with patch("uuid.UUID.__str__", return_value=expected_uuid), self.assertLogs(
-            "django_structlog.middlewares.request", logging.INFO
-        ) as log_results:
+        with (
+            patch("uuid.UUID.__str__", return_value=expected_uuid),
+            self.assertLogs(
+                "django_structlog.middlewares.request", logging.INFO
+            ) as log_results,
+        ):
             middleware(request)
 
         self.assertEqual(2, len(log_results.records))
@@ -290,9 +293,12 @@ class TestRequestMiddleware(TestCase):
 
         middleware.get_response = get_response
 
-        with patch("uuid.UUID.__str__", return_value=expected_uuid), self.assertLogs(
-            "django_structlog.middlewares.request", logging.INFO
-        ) as log_results:
+        with (
+            patch("uuid.UUID.__str__", return_value=expected_uuid),
+            self.assertLogs(
+                "django_structlog.middlewares.request", logging.INFO
+            ) as log_results,
+        ):
             middleware(request)
 
         self.assertEqual(2, len(log_results.records))
@@ -500,9 +506,12 @@ class TestRequestMiddleware(TestCase):
 
         middleware.get_response = get_response
 
-        with patch("uuid.UUID.__str__", return_value=expected_uuid), self.assertLogs(
-            logging.getLogger("django_structlog"), logging.INFO
-        ) as log_results:
+        with (
+            patch("uuid.UUID.__str__", return_value=expected_uuid),
+            self.assertLogs(
+                logging.getLogger("django_structlog"), logging.INFO
+            ) as log_results,
+        ):
             middleware(request)
 
         self.assertEqual(2, len(log_results.records))
@@ -551,9 +560,12 @@ class TestRequestMiddleware(TestCase):
 
         middleware.get_response = get_response
 
-        with patch("uuid.UUID.__str__", return_value=expected_uuid), self.assertLogs(
-            logging.getLogger("django_structlog"), logging.INFO
-        ) as log_results:
+        with (
+            patch("uuid.UUID.__str__", return_value=expected_uuid),
+            self.assertLogs(
+                logging.getLogger("django_structlog"), logging.INFO
+            ) as log_results,
+        ):
             middleware(request)
 
         self.assertEqual(2, len(log_results.records))
@@ -601,9 +613,12 @@ class TestRequestMiddleware(TestCase):
 
         middleware.get_response = get_response
 
-        with patch("uuid.UUID.__str__", return_value=expected_uuid), self.assertLogs(
-            logging.getLogger("django_structlog"), logging.INFO
-        ) as log_results:
+        with (
+            patch("uuid.UUID.__str__", return_value=expected_uuid),
+            self.assertLogs(
+                logging.getLogger("django_structlog"), logging.INFO
+            ) as log_results,
+        ):
             middleware(request)
 
         self.assertEqual(2, len(log_results.records))
@@ -652,9 +667,12 @@ class TestRequestMiddleware(TestCase):
 
         middleware.get_response = get_response
 
-        with patch("uuid.UUID.__str__", return_value=expected_uuid), self.assertLogs(
-            logging.getLogger("django_structlog"), logging.INFO
-        ) as log_results:
+        with (
+            patch("uuid.UUID.__str__", return_value=expected_uuid),
+            self.assertLogs(
+                logging.getLogger("django_structlog"), logging.INFO
+            ) as log_results,
+        ):
             middleware(request)
 
         self.assertEqual(2, len(log_results.records))
@@ -698,9 +716,12 @@ class TestRequestMiddleware(TestCase):
 
         middleware.get_response = get_response
 
-        with patch("uuid.UUID.__str__", return_value=expected_uuid), self.assertLogs(
-            logging.getLogger("django_structlog"), logging.INFO
-        ) as log_results:
+        with (
+            patch("uuid.UUID.__str__", return_value=expected_uuid),
+            self.assertLogs(
+                logging.getLogger("django_structlog"), logging.INFO
+            ) as log_results,
+        ):
             middleware(request)
 
         self.assertEqual(2, len(log_results.records))
@@ -836,13 +857,17 @@ class TestRequestMiddleware(TestCase):
         middleware = middlewares.RequestMiddleware(async_get_response)
 
         mock_request = Mock()
-        with patch(
-            "django_structlog.middlewares.request.RequestMiddleware.prepare"
-        ) as mock_prepare, patch(
-            "django_structlog.middlewares.request.RequestMiddleware.handle_response"
-        ) as mock_handle_response, self.assertLogs(
-            "django_structlog.middlewares.request", logging.WARNING
-        ) as log_results:
+        with (
+            patch(
+                "django_structlog.middlewares.request.RequestMiddleware.prepare"
+            ) as mock_prepare,
+            patch(
+                "django_structlog.middlewares.request.RequestMiddleware.handle_response"
+            ) as mock_handle_response,
+            self.assertLogs(
+                "django_structlog.middlewares.request", logging.WARNING
+            ) as log_results,
+        ):
             with self.assertRaises(asyncio.CancelledError):
                 await middleware(mock_request)
         mock_prepare.assert_called_once_with(mock_request)
@@ -862,11 +887,14 @@ class TestRequestMiddlewareRouter(TestCase):
         middleware = middlewares.RequestMiddleware(async_get_response)
 
         mock_request = Mock()
-        with patch(
-            "django_structlog.middlewares.request.RequestMiddleware.prepare"
-        ) as mock_prepare, patch(
-            "django_structlog.middlewares.request.RequestMiddleware.handle_response"
-        ) as mock_handle_response:
+        with (
+            patch(
+                "django_structlog.middlewares.request.RequestMiddleware.prepare"
+            ) as mock_prepare,
+            patch(
+                "django_structlog.middlewares.request.RequestMiddleware.handle_response"
+            ) as mock_handle_response,
+        ):
             response = await middleware(mock_request)
         self.assertEqual(response, mock_response)
         mock_prepare.assert_called_once_with(mock_request)
@@ -881,11 +909,14 @@ class TestRequestMiddlewareRouter(TestCase):
         middleware = middlewares.RequestMiddleware(get_response)
 
         mock_request = Mock()
-        with patch(
-            "django_structlog.middlewares.request.RequestMiddleware.prepare"
-        ) as mock_prepare, patch(
-            "django_structlog.middlewares.request.RequestMiddleware.handle_response"
-        ) as mock_handle_response:
+        with (
+            patch(
+                "django_structlog.middlewares.request.RequestMiddleware.prepare"
+            ) as mock_prepare,
+            patch(
+                "django_structlog.middlewares.request.RequestMiddleware.handle_response"
+            ) as mock_handle_response,
+        ):
             response = middleware(mock_request)
         self.assertEqual(response, mock_response)
         mock_prepare.assert_called_once_with(mock_request)
@@ -918,11 +949,12 @@ class TestSyncStreamingContentWrapper(TestCase):
         wrapped_streaming_content = sync_streaming_content_wrapper(
             streaming_content(), {"foo": "bar"}
         )
-        with self.assertLogs(
-            __name__, logging.INFO
-        ) as streaming_content_log_results, self.assertLogs(
-            "django_structlog.middlewares.request", logging.INFO
-        ) as log_results:
+        with (
+            self.assertLogs(__name__, logging.INFO) as streaming_content_log_results,
+            self.assertLogs(
+                "django_structlog.middlewares.request", logging.INFO
+            ) as log_results,
+        ):
             self.assertEqual(result, next(wrapped_streaming_content))
 
         self.assertEqual(1, len(log_results.records))
@@ -963,11 +995,12 @@ class TestSyncStreamingContentWrapper(TestCase):
         wrapped_streaming_content = sync_streaming_content_wrapper(
             streaming_content(), {"foo": "bar"}
         )
-        with self.assertLogs(
-            __name__, logging.INFO
-        ) as streaming_content_log_results, self.assertLogs(
-            "django_structlog.middlewares.request", logging.INFO
-        ) as log_results:
+        with (
+            self.assertLogs(__name__, logging.INFO) as streaming_content_log_results,
+            self.assertLogs(
+                "django_structlog.middlewares.request", logging.INFO
+            ) as log_results,
+        ):
             self.assertEqual(result, next(wrapped_streaming_content))
 
         self.assertEqual(1, len(log_results.records))
@@ -1010,11 +1043,12 @@ class TestASyncStreamingContentWrapper(TestCase):
         wrapped_streaming_content = async_streaming_content_wrapper(
             streaming_content(), {"foo": "bar"}
         )
-        with self.assertLogs(
-            __name__, logging.INFO
-        ) as streaming_content_log_results, self.assertLogs(
-            "django_structlog.middlewares.request", logging.INFO
-        ) as log_results:
+        with (
+            self.assertLogs(__name__, logging.INFO) as streaming_content_log_results,
+            self.assertLogs(
+                "django_structlog.middlewares.request", logging.INFO
+            ) as log_results,
+        ):
             self.assertEqual(result, await wrapped_streaming_content.__anext__())
 
         self.assertEqual(1, len(log_results.records))
@@ -1056,11 +1090,12 @@ class TestASyncStreamingContentWrapper(TestCase):
         wrapped_streaming_content = async_streaming_content_wrapper(
             streaming_content(), {"foo": "bar"}
         )
-        with self.assertLogs(
-            __name__, logging.INFO
-        ) as streaming_content_log_results, self.assertLogs(
-            "django_structlog.middlewares.request", logging.INFO
-        ) as log_results:
+        with (
+            self.assertLogs(__name__, logging.INFO) as streaming_content_log_results,
+            self.assertLogs(
+                "django_structlog.middlewares.request", logging.INFO
+            ) as log_results,
+        ):
             self.assertEqual(result, await wrapped_streaming_content.__anext__())
 
         self.assertEqual(1, len(log_results.records))

--- a/test_app/tests/test_commands.py
+++ b/test_app/tests/test_commands.py
@@ -13,11 +13,12 @@ class TestCommands(TestCase):
             def handle(self, *args, **options):
                 structlog.getLogger("command").info("command_event")
 
-        with self.assertLogs(
-            "command", logging.INFO
-        ) as command_log_results, self.assertLogs(
-            "django_structlog.commands", logging.INFO
-        ) as django_structlog_commands_log_results:
+        with (
+            self.assertLogs("command", logging.INFO) as command_log_results,
+            self.assertLogs(
+                "django_structlog.commands", logging.INFO
+            ) as django_structlog_commands_log_results,
+        ):
             call_command(Command())
 
         self.assertEqual(1, len(command_log_results.records))
@@ -47,13 +48,13 @@ class TestCommands(TestCase):
             def handle(self, *args, **options):
                 structlog.getLogger("nested_command").info("nested_command_event")
 
-        with self.assertLogs(
-            "command", logging.INFO
-        ) as command_log_results, self.assertLogs(
-            "nested_command", logging.INFO
-        ), self.assertLogs(
-            "django_structlog.commands", logging.INFO
-        ) as django_structlog_commands_log_results:
+        with (
+            self.assertLogs("command", logging.INFO) as command_log_results,
+            self.assertLogs("nested_command", logging.INFO),
+            self.assertLogs(
+                "django_structlog.commands", logging.INFO
+            ) as django_structlog_commands_log_results,
+        ):
             call_command(Command())
 
         self.assertEqual(2, len(command_log_results.records))


### PR DESCRIPTION
- add python 3.13 to test matrix
- drop support of python 3.8
- use psycopg3