### PR TITLE
readthedocs python 3.13

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,7 +9,7 @@ version: 2
 build:
   os: ubuntu-24.04
   tools:
-    python: "3.12"
+    python: "3.13"
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:


### PR DESCRIPTION
- [x] readthedocs needs to support python 3.13 https://github.com/readthedocs/readthedocs.org/issues/11671