### PR TITLE
readthedocs python 3.13 2nd attempt

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,7 +9,7 @@ version: 2
 build:
   os: ubuntu-24.04
   tools:
-    python: "3.12"
+    python: "3.13"
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:


### PR DESCRIPTION
- [x] When readthedocs needs to support python 3.13 will be deployed https://github.com/readthedocs/readthedocs.org/issues/11671


This reverts commit 21756f855774d40e533ba8a8abea2e1fd2516953.

#675 was rollbacked because readthedocs haven't deployed the fix yet.