### PR TITLE
fix: propagate exceptions in streaming response wrappers

### DIFF
--- a/django_structlog/middlewares/request.py
+++ b/django_structlog/middlewares/request.py
@@ -61,6 +61,7 @@ def sync_streaming_content_wrapper(
                 yield chunk
         except Exception:
             logger.exception("streaming_failed")
+            raise
         else:
             logger.info("streaming_finished")
 
@@ -78,6 +79,7 @@ async def async_streaming_content_wrapper(
             raise
         except Exception:
             logger.exception("streaming_failed")
+            raise
         else:
             logger.info("streaming_finished")
 

--- a/test_app/tests/middlewares/test_request.py
+++ b/test_app/tests/middlewares/test_request.py
@@ -1011,7 +1011,10 @@ class TestSyncStreamingContentWrapper(TestCase):
     def test_failure(self) -> None:
         result = Mock()
 
-        exception = Exception()
+        class CustomException(Exception):
+            pass
+
+        exception = CustomException()
 
         def streaming_content() -> Generator[Any, None, None]:
             self.logger.info("streaming_content")
@@ -1040,7 +1043,7 @@ class TestSyncStreamingContentWrapper(TestCase):
         with self.assertLogs(
             "django_structlog.middlewares.request", logging.INFO
         ) as log_results:
-            self.assertRaises(Exception, next, wrapped_streaming_content)
+            self.assertRaises(CustomException, next, wrapped_streaming_content)
 
         self.assertEqual(1, len(streaming_content_log_results.records))
         record = streaming_content_log_results.records[0]
@@ -1108,7 +1111,10 @@ class TestASyncStreamingContentWrapper(TestCase):
     async def test_failure(self) -> None:
         result = Mock()
 
-        exception = Exception()
+        class CustomException(Exception):
+            pass
+
+        exception = CustomException()
 
         async def streaming_content() -> AsyncGenerator[Any, None]:
             self.logger.info("streaming_content")
@@ -1137,7 +1143,7 @@ class TestASyncStreamingContentWrapper(TestCase):
         with self.assertLogs(
             "django_structlog.middlewares.request", logging.INFO
         ) as log_results:
-            with self.assertRaises(StopAsyncIteration):
+            with self.assertRaises(CustomException):
                 await wrapped_streaming_content.__anext__()
 
         self.assertEqual(1, len(streaming_content_log_results.records))


### PR DESCRIPTION
When streaming responses we noticed a couple of oddities:
1. our exception collection middleware, which appears after `django_structlog.middlewares.RequestMiddleware` in our list of middlewares, was not collecting exceptions that occurred during generating of streaming responses
2. ALL streaming responses were responding with a 200 status code, even those that encountered an exception

On investigation we noticed that `django_structlog` was swallowing streaming exceptions. From our perspective `django_structlog` should ideally only have logging related side effects and requests/responses shouldn't be altered otherwise.