### PR TITLE
Small docs grammar fix

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -404,7 +404,7 @@ Other libraries alike may be affected by this change.
 Internal changes in how ``RequestMiddleware`` handles exceptions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-This only affects you if you implemented a middleware inheriting from ``RequestMiddleware`` and you overrided the ``process_exception`` method.
+This only affects you if you implemented a middleware inheriting from ``RequestMiddleware`` and you overrode the ``process_exception`` method.
 
 Did you?
 


### PR DESCRIPTION
Hi,

First of all, thank you for this project. A real time-saver for shoving structlog into an existing Django project that almost-but-not-quite predates `structlog` itself!

I was just reading through the README and the use of the word "overridded" stuck out to me. Hope you don't mind the drive-by PR. Not trying to be a pedant! 😛 Only submitting because it only took 5 seconds to submit and I'm assuming 5 seconds to merge!

The past tense of override is "overrode", see:
- https://www.oxfordlearnersdictionaries.com/definition/english/override
- https://dictionary.cambridge.org/dictionary/english/override

Cheers 👋