### PR TITLE
feat(celery): set task.name as context var

### DIFF
--- a/django_structlog/celery/receivers.py
+++ b/django_structlog/celery/receivers.py
@@ -88,12 +88,13 @@ class CeleryReceiver:
     ) -> None:
         structlog.contextvars.clear_contextvars()
         structlog.contextvars.bind_contextvars(task_id=task_id)
+        structlog.contextvars.bind_contextvars(task=task.name)
         metadata = getattr(task.request, "__django_structlog__", {})
         structlog.contextvars.bind_contextvars(**metadata)
         signals.bind_extra_task_metadata.send(
             sender=self.receiver_task_prerun, task=task, logger=logger
         )
-        logger.info("task_started", task=task.name)
+        logger.info("task_started")
 
     def receiver_task_retry(
         self,

--- a/django_structlog/celery/receivers.py
+++ b/django_structlog/celery/receivers.py
@@ -87,8 +87,7 @@ class CeleryReceiver:
         self, task_id: str, task: Any, *args: Any, **kwargs: Any
     ) -> None:
         structlog.contextvars.clear_contextvars()
-        structlog.contextvars.bind_contextvars(task_id=task_id)
-        structlog.contextvars.bind_contextvars(task=task.name)
+        structlog.contextvars.bind_contextvars(task_id=task_id, task=task.name)
         metadata = getattr(task.request, "__django_structlog__", {})
         structlog.contextvars.bind_contextvars(**metadata)
         signals.bind_extra_task_metadata.send(

--- a/django_structlog/celery/receivers.py
+++ b/django_structlog/celery/receivers.py
@@ -98,7 +98,6 @@ class CeleryReceiver:
         task.request._django_structlog_started_at = time.monotonic_ns()
         logger.info("task_started")
 
-
     def receiver_task_retry(
         self,
         request: Optional[Any] = None,

--- a/test_app/tests/celery/test_receivers.py
+++ b/test_app/tests/celery/test_receivers.py
@@ -221,6 +221,7 @@ class TestReceivers(TestCase):
         self.assertDictEqual(
             {
                 "task_id": task_id,
+                "task": "task_name",
                 "request_id": expected_request_uuid,
                 "user_id": expected_user_id,
             },


### PR DESCRIPTION
I believe it is useful to have the task name logged on all logs, especially the `task_succeeded` log.