### PR TITLE
Add 5xx and cancelled request log level config

### DIFF
--- a/django_structlog/app_settings.py
+++ b/django_structlog/app_settings.py
@@ -16,6 +16,12 @@ class AppSettings:
         return getattr(settings, self.PREFIX + "IP_LOGGING_ENABLED", True)
 
     @property
+    def REQUEST_CANCELLED_LOG_LEVEL(self) -> int:
+        return getattr(
+            settings, self.PREFIX + "REQUEST_CANCELLED_LOG_LEVEL", logging.WARNING
+        )
+
+    @property
     def STATUS_4XX_LOG_LEVEL(self) -> int:
         return getattr(settings, self.PREFIX + "STATUS_4XX_LOG_LEVEL", logging.WARNING)
 

--- a/django_structlog/middlewares/request.py
+++ b/django_structlog/middlewares/request.py
@@ -125,7 +125,7 @@ class RequestMiddleware:
         try:
             response = await cast(Awaitable["HttpResponse"], self.get_response(request))
         except asyncio.CancelledError:
-            logger.warning("request_cancelled")
+            logger.log(app_settings.REQUEST_CANCELLED_LOG_LEVEL, "request_cancelled")
             raise
         await sync.sync_to_async(self.handle_response)(request, response)
         return response

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -29,6 +29,8 @@ Settings
 +------------------------------------------+---------+-----------------+-------------------------------------------------------------------------------+
 | DJANGO_STRUCTLOG_STATUS_5XX_LOG_LEVEL    | int     | logging.ERROR   | Log level of 5XX status codes                                                 |
 +------------------------------------------+---------+-----------------+-------------------------------------------------------------------------------+
+| DJANGO_STRUCTLOG_REQUEST_CANCELLED_LOG_LEVEL | int | logging.WARNING | Log level of request_cancelled messages                                       |
++------------------------------------------+---------+-----------------+-------------------------------------------------------------------------------+
 | DJANGO_STRUCTLOG_COMMAND_LOGGING_ENABLED | boolean | False           | See :ref:`commands`                                                           |
 +------------------------------------------+---------+-----------------+-------------------------------------------------------------------------------+
 | DJANGO_STRUCTLOG_USER_ID_FIELD           | string  | ``"pk"``        | Change field used to identify user in logs, ``None`` to disable user binding  |

--- a/test_app/tests/test_app_settings.py
+++ b/test_app/tests/test_app_settings.py
@@ -1,3 +1,5 @@
+import logging
+
 from django.test import TestCase
 
 from django_structlog import app_settings
@@ -15,6 +17,16 @@ class TestAppSettings(TestCase):
 
         with self.settings(DJANGO_STRUCTLOG_CELERY_ENABLED=False):
             self.assertFalse(settings.CELERY_ENABLED)
+
+    def test_request_cancelled_log_level_default(self) -> None:
+        settings = app_settings.AppSettings()
+        self.assertEqual(settings.REQUEST_CANCELLED_LOG_LEVEL, logging.WARNING)
+
+    def test_request_cancelled_log_level_custom(self) -> None:
+        settings = app_settings.AppSettings()
+
+        with self.settings(DJANGO_STRUCTLOG_REQUEST_CANCELLED_LOG_LEVEL=logging.DEBUG):
+            self.assertEqual(settings.REQUEST_CANCELLED_LOG_LEVEL, logging.DEBUG)
 
     def test_status_5xx_log_level_default(self) -> None:
         settings = app_settings.AppSettings()


### PR DESCRIPTION
Adds the following settings:

`REQUEST_CANCELLED_LOG_LEVEL`: Defines the log level for the `request_cancelled` log events. Defaults to `WARNING`.
`STATUS_5XX_LOG_LEVEL`: Defines the log level for the `request_finished` log event with 5XX response status. Defaults to `ERROR`.